### PR TITLE
Update groovy-all to version 2.4.21

### DIFF
--- a/restAPIExtensions/resourceNameRestAPI/pom.xml
+++ b/restAPIExtensions/resourceNameRestAPI/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.4</version>
+            <version>2.4.21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/restAPIExtensions/tahitiRestApiExtension/pom.xml
+++ b/restAPIExtensions/tahitiRestApiExtension/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.4</version>
+            <version>2.4.21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/restAPIExtensions/tahitiUsersOfManagerExtension/pom.xml
+++ b/restAPIExtensions/tahitiUsersOfManagerExtension/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>2.4.4</version>
+            <version>2.4.21</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I've updated the version of the `org.codehaus.groovy:groovy-all` dependency to `2.4.21` in all `pom.xml` files to address known security vulnerabilities CVE-2016-6814 and CVE-2020-17521.